### PR TITLE
Add TabRouter

### DIFF
--- a/addon/-private/routers/switch-router.ts
+++ b/addon/-private/routers/switch-router.ts
@@ -18,6 +18,8 @@ import { MountedNode, MountedNodeSet } from "../mounted-router";
 export interface SwitchOptions extends BaseOptions {}
 
 export class SwitchRouter extends BaseRouter implements RouterReducer {
+  defaultKey = "SwitchRouterBase";
+
   dispatch(action: RouterActions, state: RouterState) {
     let activeRouteState = state.routes[state.index];
     let nextRouteState = this.dispatchTo([activeRouteState], action);
@@ -97,7 +99,7 @@ export class SwitchRouter extends BaseRouter implements RouterReducer {
   getInitialState(options: InitialStateOptions = {}): RouterState {
     let childRoutes = this.children.map(c => this.resetChildRoute(c));
     return {
-      key: options.key || "SwitchRouterBase",
+      key: options.key || this.defaultKey,
       params: undefined,
       routeName: this.name,
       componentName: "ecr-switch",

--- a/addon/-private/routers/tab-router.ts
+++ b/addon/-private/routers/tab-router.ts
@@ -1,0 +1,58 @@
+import {
+  RouterReducer,
+  RouterState,
+  RouteableState,
+  ReducerResult
+} from "../routeable";
+import {
+  handledAction,
+  unhandledAction
+} from "./base-router";
+import {
+  SwitchRouter,
+  SwitchOptions
+} from "./switch-router";
+import { NavigateAction } from "../actions/types";
+
+export interface TabOptions extends SwitchOptions {}
+
+/* A TabRouter is a SwitchRouter that doesn't reset child state when switching between child routes */
+export class TabRouter extends SwitchRouter implements RouterReducer {
+  defaultKey = "TabRouterBase";
+
+  navigateAway(action: NavigateAction, state: RouterState): ReducerResult {
+    // TODO: it seems wasteful to deeply recurse on every unknown route.
+    // consider adding a cache, or building one at the beginning?
+    for (let i = 0; i < this.children.length; ++i) {
+      if (state.index === i) {
+        // skip the active route, which we already checked.
+        continue;
+      }
+
+      let routeable = this.children[i];
+      if (routeable.name === action.payload.routeName) {
+        let childRouteState = state.routes[i];
+        return this.switchToRoute(state, childRouteState, i);
+      } else if (routeable.isRouter) {
+        let initialChildRouteState = this.resetChildRoute(routeable);
+        let navigationResult = routeable.dispatch(action, initialChildRouteState);
+        if (navigationResult.handled) {
+          return this.switchToRoute(state, navigationResult.state, i);
+        }
+      }
+    }
+
+    return unhandledAction();
+  }
+
+  switchToRoute(state: RouterState, childRouteState: RouteableState, i: number) {
+    let routes = [...state.routes];
+    routes[i] = childRouteState;
+
+    return handledAction({
+      ...state,
+      routes,
+      index: i,
+    });
+  }
+}

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -3,6 +3,7 @@ import { RouterReducer, RouteableReducer, Resolver } from "./-private/routeable"
 import { RouteOptions, Route } from "./-private/route";
 import { StackOptions, StackRouter } from "./-private/routers/stack-router";
 import { SwitchOptions, SwitchRouter } from "./-private/routers/switch-router";
+import { TabOptions, TabRouter } from "./-private/routers/tab-router";
 import { PublicRoute } from "./-private/public-route";
 
 export function mount(routerMap: RouterReducer, resolver: Resolver) : MountedRouter {
@@ -19,6 +20,10 @@ export function stackRouter(name: string, children: RouteableReducer[], options:
 
 export function switchRouter(name: string, children: RouteableReducer[], options: SwitchOptions = {}) {
   return new SwitchRouter(name, children, options);
+}
+
+export function tabRouter(name: string, children: RouteableReducer[], options: TabOptions = {}) {
+  return new TabRouter(name, children, options);
 }
 
 export const NavigatorRoute = PublicRoute;

--- a/tests/unit/routers/tab-router-test.ts
+++ b/tests/unit/routers/tab-router-test.ts
@@ -1,0 +1,139 @@
+import { test, module } from 'ember-qunit';
+import { route, tabRouter, stackRouter } from 'ember-navigator';
+import { _TESTING_ONLY_normalize_keys } from 'ember-navigator/-private/key-generator';
+import { navigate } from './helpers';
+import { RouterState, StackRouterState } from 'ember-navigator/-private/routeable';
+
+module('Unit - TabRouter test', function(hooks) {
+  hooks.beforeEach(() => _TESTING_ONLY_normalize_keys());
+
+  test("initial state", function (assert) {
+    let router = tabRouter('root', [
+      route('foo'),
+      route('bar'),
+    ]);
+    let state = router.getInitialState();
+    assert.deepEqual(state, {
+      "componentName": "ecr-switch",
+      "index": 0,
+      "key": "TabRouterBase",
+      "params": undefined,
+      "routeName": "root",
+      "routes": [
+        {
+          "componentName": "foo",
+          "key": "foo",
+          "params": undefined,
+          "routeName": "foo" ,
+        },
+        {
+          "componentName": "bar",
+          "key": "bar",
+          "params": undefined,
+          "routeName": "bar",
+        }
+      ]
+    });
+  });
+
+  test("navigating between shallow routes", function(assert) {
+    let router = buildExampleRouter();
+    let initialState = router.getInitialState();
+    let state2 = navigate(router, initialState, 'b1');
+    assert.equal(state2.index, 1);
+    assert.deepEqual(state2.routes[1], {
+      "componentName": "ecr-stack",
+      "headerComponentName": "ecr-header",
+      "headerMode": "float",
+      "index": 0,
+      "key": "b",
+      "params": {},
+      "routeName": "b",
+      "routes": [
+        {
+          "componentName": "b1",
+          "key": "b1",
+          "params": null,
+          "routeName": "b1"
+        }
+      ]
+    } as RouterState);
+    let state3 = navigate(router, initialState, 'b2');
+    let innerRoute = state3.routes[1] as RouterState;
+    assert.equal(innerRoute.index, 1);
+    assert.deepEqual(innerRoute.routes.map(r => r.routeName), ["b1", "b2"]);
+  });
+
+  test("navigating to the parent route if a route you're in should be a no-op", function(assert) {
+    let router = tabRouter('a', [
+      stackRouter('b', [
+        route('c'),
+      ])
+    ]);
+
+    let initialState = router.getInitialState();
+    let state2 = navigate(router, initialState, 'b');
+    assert.equal(initialState, state2);
+  });
+
+  test("navigating away", function(assert) {
+    let router = tabRouter('root', [
+      route('a'),
+      route('b'),
+    ]);
+
+    let initialState = router.getInitialState();
+    let state2 = navigate(router, initialState, 'b');
+    assert.equal(state2.index, 1);
+    let state3 = navigate(router, state2, 'a');
+    assert.equal(state3.index, 0);
+  });
+
+  test("no-op navigation within active route results in same state object being returned", function(assert) {
+    let router = buildExampleRouter();
+    let initialState = router.getInitialState();
+    let state2 = navigate(router, initialState, 'a1');
+    assert.equal(initialState, state2);
+  });
+
+  test("navigation within active route", function(assert) {
+    let router = buildExampleRouter();
+    let initialState = router.getInitialState();
+    let state2 = navigate(router, initialState, 'a2');
+    assert.notEqual(state2, initialState);
+    assert.equal(state2.index, 0);
+    let newNestedRoute = (state2.routes[0] as RouterState);
+    assert.equal(newNestedRoute.index, 1);
+  });
+
+  test("navigation to another tab route preserves the state of each tab", function(assert) {
+    let router = buildExampleRouter();
+    let initialState = router.getInitialState();
+    let state2 = navigate(router, initialState, 'a2');
+    let state3 = navigate(router, state2, 'b');
+    let state4 = navigate(router, state3, 'a');
+    assert.equal(state4.index, 0, 'first tab should be active');
+    let tabRouterState = state4.routes[0] as any;
+    assert.equal(tabRouterState.index, 1,  'first tab should still be drilled down one level');
+    assert.equal(tabRouterState.routes.length, 2, 'first tab should still be drilled down one level');
+    assert.equal(tabRouterState.routes[1].routeName, 'a2', 'first tab should still have a2 active');
+  });
+});
+
+function buildExampleRouter() {
+  return tabRouter('root', [
+    stackRouter('a', [
+      route('a1'),
+      route('a2'),
+    ]),
+    stackRouter('b', [
+      route('b1'),
+      route('b2'),
+    ]),
+    stackRouter('c', [
+      route('c1'),
+      route('c2'),
+    ]),
+    route('shallow'),
+  ]);
+}


### PR DESCRIPTION
Add TabRouter, a subclass of SwitchRouter that does not reset it's state when switching between tabs