### PR TITLE
NavigatorRoute: add `parent`, `parentRoute`, `parentRouter`, and other cleanup

### DIFF
--- a/addon/-private/mounted-node.ts
+++ b/addon/-private/mounted-node.ts
@@ -72,6 +72,10 @@ export class MountedNode implements MountableNode {
     return this.routeableState.params;
   }
 
+  get isRouter() {
+    return !!(this.routeableState as any).routes;
+  }
+
   getHeaderConfig(): any {
     let routerState = this.routeableState as RouterState;
 

--- a/addon/-private/mounted-node.ts
+++ b/addon/-private/mounted-node.ts
@@ -23,11 +23,13 @@ export class MountedNode implements MountableNode {
   id: number;
   header?: any;
   mountedRouter: MountedRouter;
+  parentNode: MountedNode | null;
 
-  constructor(mountedRouter: MountedRouter, routeableState: RouteableState) {
+  constructor(mountedRouter: MountedRouter, parentNode: MountedNode | null, routeableState: RouteableState) {
     // TODO: odd that we pass in routeableState but don't stash it? Maybe we should call update immediately?
     this.id = ID++;
     this.mountedRouter = mountedRouter;
+    this.parentNode = parentNode;
     this.routeableState = routeableState;
     this.route = this.mountedRouter.createNavigatorRoute(this);
     this.childNodes = {};

--- a/addon/-private/mounted-node.ts
+++ b/addon/-private/mounted-node.ts
@@ -1,0 +1,85 @@
+import { RouterState, RouteableState, MountableNode } from "./routeable";
+import NavigatorRoute from "./navigator-route";
+import MountedRouter from "./mounted-router";
+
+export type MountedNodeSet = { [key: string]: MountedNode };
+
+let ID = 0;
+
+/**
+ * A MountedNode is an internal/private class that represents a node in the router tree that
+ * has been fully initialized (similar to components in ember that have been fully rendered
+ * into the DOM, or "mounted" components in React).
+ *
+ * Apps should not import, subclass, or interact with this class; instead, apps should
+ * define subclasses of {NavigatorRoute}, which is the public API for customizing
+ * behavior when the route is mounted.
+ */
+
+export class MountedNode implements MountableNode {
+  childNodes: MountedNodeSet;
+  routeableState: RouteableState;
+  route: NavigatorRoute;
+  id: number;
+  header?: any;
+  mountedRouter: MountedRouter;
+
+  constructor(mountedRouter: MountedRouter, routeableState: RouteableState) {
+    // TODO: odd that we pass in routeableState but don't stash it? Maybe we should call update immediately?
+    this.id = ID++;
+    this.mountedRouter = mountedRouter;
+    this.routeableState = routeableState;
+    this.route = this.mountedRouter.createNavigatorRoute(this);
+    this.childNodes = {};
+    this.mount();
+  }
+
+  update(routeableState: RouteableState) {
+    // TODO: is this check needed? when else would this change?
+    if (this.routeableState === routeableState) { return; }
+
+    this.route.update(routeableState);
+    this.routeableState = routeableState;
+  }
+
+  mount() {
+    this.route.mount();
+  }
+
+  unmount() {
+    this.route.unmount();
+  }
+
+  resolve(name: string) {
+    return this.mountedRouter.resolve(name);
+  }
+
+  get componentName() {
+    return this.routeableState.componentName;
+  }
+
+  get routeName() {
+    return this.routeableState.routeName;
+  }
+
+  get key() {
+    return this.routeableState.key;
+  }
+
+  get params() {
+    return this.routeableState.params;
+  }
+
+  getHeaderConfig(): any {
+    let routerState = this.routeableState as RouterState;
+
+    if (routerState.routes) {
+      let key = routerState.routes[routerState.index].key;
+      let child = this.childNodes[key];
+      return child && child.getHeaderConfig();
+    } else {
+      // this is leaf route, check the NavigatorRoute
+      return (this.route as any).header;
+    }
+  }
+}

--- a/addon/-private/mounted-router.ts
+++ b/addon/-private/mounted-router.ts
@@ -1,90 +1,9 @@
-import { RouterReducer, RouterState, RouteableState, MountableNode, Resolver } from "./routeable";
+import { RouterReducer, RouterState, Resolver } from "./routeable";
 import { RouterActions, NavigateParams, PopParams } from "./actions/types";
 import { navigate, pop } from "./actions/actions";
-import NavigatorRoute from "./navigator-route";
 import { set } from "@ember/object";
 import { sendEvent } from '@ember/object/events';
-
-export type MountedNodeSet = { [key: string]: MountedNode };
-
-let ID = 0;
-
-/**
- * A MountedNode is an internal/private class that represents a node in the router tree that
- * has been fully initialized (similar to components in ember that have been fully rendered
- * into the DOM, or "mounted" components in React).
- * 
- * Apps should not import, subclass, or interact with this class; instead, apps should
- * define subclasses of {NavigatorRoute}, which is the public API for customizing
- * behavior when the route is mounted.
- */
-export class MountedNode implements MountableNode {
-  childNodes: MountedNodeSet;
-  routeableState: RouteableState;
-  route: NavigatorRoute;
-  id: number;
-  header?: any;
-  mountedRouter: MountedRouter;
-
-  constructor(mountedRouter: MountedRouter, routeableState: RouteableState) {
-    // TODO: odd that we pass in routeableState but don't stash it? Maybe we should call update immediately?
-    this.id = ID++;
-    this.mountedRouter = mountedRouter;
-    this.routeableState = routeableState;
-    this.route = this.mountedRouter.createNavigatorRoute(this);
-    this.childNodes = {};
-    this.mount();
-  }
-
-  update(routeableState: RouteableState) {
-    // TODO: is this check needed? when else would this change?
-    if (this.routeableState === routeableState) { return; }
-
-    this.route.update(routeableState);
-    this.routeableState = routeableState;
-  }
-
-  mount() {
-    this.route.mount();
-  }
-
-  unmount() {
-    this.route.unmount();
-  }
-
-  resolve(name: string) {
-    return this.mountedRouter.resolve(name);
-  }
-
-  get componentName() {
-    return this.routeableState.componentName;
-  }
-
-  get routeName() {
-    return this.routeableState.routeName;
-  }
-
-  get key() {
-    return this.routeableState.key;
-  }
-
-  get params() {
-    return this.routeableState.params;
-  }
-
-  getHeaderConfig() : any {
-    let routerState = this.routeableState as RouterState;
-
-    if (routerState.routes) {
-      let key = routerState.routes[routerState.index].key;
-      let child = this.childNodes[key];
-      return child && child.getHeaderConfig();
-    } else {
-      // this is leaf route, check the NavigatorRoute
-      return (this.route as any).header;
-    }
-  }
-}
+import { MountedNode } from "./mounted-node";
 
 export default class MountedRouter {
   router: RouterReducer;

--- a/addon/-private/mounted-router.ts
+++ b/addon/-private/mounted-router.ts
@@ -9,9 +9,15 @@ export type MountedNodeSet = { [key: string]: MountedNode };
 
 let ID = 0;
 
-// A MountedNode is the "internal" stateful node that the routing API doesn't have access to.
-// The Route is the public API object that we pass into components.
-
+/**
+ * A MountedNode is an internal/private class that represents a node in the router tree that
+ * has been fully initialized (similar to components in ember that have been fully rendered
+ * into the DOM, or "mounted" components in React).
+ * 
+ * Apps should not import, subclass, or interact with this class; instead, apps should
+ * define subclasses of {NavigatorRoute}, which is the public API for customizing
+ * behavior when the route is mounted.
+ */
 export class MountedNode implements MountableNode {
   childNodes: MountedNodeSet;
   routeableState: RouteableState;

--- a/addon/-private/mounted-router.ts
+++ b/addon/-private/mounted-router.ts
@@ -15,7 +15,7 @@ export default class MountedRouter {
     this.resolver = resolver;
     this.router = router;
     this.state = router.getInitialState();
-    this.rootNode = new MountedNode(this, this.state);
+    this.rootNode = new MountedNode(this, null, this.state);
     this._update();
   }
 

--- a/addon/-private/navigator-route.ts
+++ b/addon/-private/navigator-route.ts
@@ -1,6 +1,7 @@
 import { MountableNode } from "./routeable";
 import { notifyPropertyChange } from "@ember/object";
 import { NavigateParams, PopParams } from "./actions/types";
+import { MountedNode } from "./mounted-node";
 
 /**
  * NavigatorRoute is part of the public API of ember-navigator; it is a class
@@ -41,19 +42,59 @@ export default class NavigatorRoute {
   }
 
   /**
+   * Returns the navigation key that uniquely identifies the route within a router tree;
+   * this is a value that is either passed in as an option to `navigate()`, or is
+   * auto-generated if no such value is passed to `navigate()`
+   */
+  get key() {
+    return this.node.key;
+  }
+
+  /**
    * Returns the name of this route as specified in the mapping DSL (e.g. `route('foo')`)
    */
   get name() {
     return this.node.routeName;
   }
 
-  get parentRoute(): NavigatorRoute | null {
+  /**
+   * Returns the immediate parent route or router. For example, if this is the 3rd route
+   * within a stack router, `parent()` will return the 2nd NavigatorRoute in the stack.
+   */
+  get parent(): NavigatorRoute | null {
     const parentNode = this.node.parentNode;
     if (!parentNode) {
       return null;
     }
 
     return (parentNode as MountableNode).route;
+  }
+
+  /**
+   * Returns the nearest parent router, e.g. the stack router that this route is mounted in.
+   */
+  get parentRouter(): NavigatorRoute | null {
+    let cur: NavigatorRoute | null = this;
+    while (cur && !(cur.node as MountedNode).isRouter) {
+      cur = cur.parent;
+    }
+    return cur;
+  }
+
+  /**
+   * Returns the parent route, and null if there is no parent, or the parent is a router.
+   */
+  get parentRoute(): NavigatorRoute | null {
+    const parent = this.parent;
+    if (!parent) {
+      return null;
+    }
+
+    if ((parent.node as MountedNode).isRouter) {
+      return null;
+    } else {
+      return parent;
+    }
   }
 
   // Public overridable hooks:

--- a/addon/-private/navigator-route.ts
+++ b/addon/-private/navigator-route.ts
@@ -47,9 +47,13 @@ export default class NavigatorRoute {
     return this.node.routeName;
   }
 
-  get parentRoute() {
-    // return this.node.params || {};
-    return null;
+  get parentRoute(): NavigatorRoute | null {
+    const parentNode = this.node.parentNode;
+    if (!parentNode) {
+      return null;
+    }
+
+    return (parentNode as MountableNode).route;
   }
 
   // Public overridable hooks:

--- a/addon/-private/navigator-route.ts
+++ b/addon/-private/navigator-route.ts
@@ -2,6 +2,11 @@ import { MountableNode } from "./routeable";
 import { notifyPropertyChange } from "@ember/object";
 import { NavigateParams, PopParams } from "./actions/types";
 
+/**
+ * NavigatorRoute is part of the public API of ember-navigator; it is a class
+ * that is meant to be subclassed with various lifecycle hooks that can be
+ * overridden in the subclass.
+ */
 export default class NavigatorRoute {
   node: MountableNode;
 
@@ -25,15 +30,39 @@ export default class NavigatorRoute {
 
   update(_state: any) {
     // this is how we signal to components to re-render with the new state.
-    notifyPropertyChange(this, 'node')
+    notifyPropertyChange(this, "node");
   }
 
+  /**
+   * Returns the params hash passed to this route (mostly via the `navigate()` method)
+   */
   get params() {
     return this.node.params || {};
   }
 
-  unmount() {}
+  /**
+   * Returns the name of this route as specified in the mapping DSL (e.g. `route('foo')`)
+   */
+  get name() {
+    return this.node.routeName;
+  }
+
+  get parentRoute() {
+    // return this.node.params || {};
+    return null;
+  }
+
+  // Public overridable hooks:
+
+  /**
+   * `mount` is called after transitioning to a new route, or pushing a stack frame;
+   * Within this hook, you can access `this.params` to access any params passed into
+   * this route (such as model IDs or any other information)
+   */
   mount() {}
-  focus() {}
-  blur() {}
+
+  /**
+   * `unmount` is called after the route has been removed from the routing tree.
+   */
+  unmount() {}
 }

--- a/addon/-private/route-reducer.ts
+++ b/addon/-private/route-reducer.ts
@@ -7,7 +7,7 @@ import {
 } from "./routeable";
 import { generateKey } from "./key-generator";
 import { RouterActions } from "./actions/types";
-import { MountedNode } from "./mounted-router";
+import { MountedNode } from "./mounted-node";
 
 export type RouteOptions = {
   componentName?: string;

--- a/addon/-private/route-reducer.ts
+++ b/addon/-private/route-reducer.ts
@@ -1,5 +1,4 @@
 import {
-  RouteReducer,
   RouteableReducer,
   RouteState,
   RouterState,
@@ -14,7 +13,17 @@ export type RouteOptions = {
   componentName?: string;
 };
 
-export class Route implements RouteReducer {
+/**
+ * This is the reducer object returned by the `route()` function in the mapping DSL, e.g.
+ *
+ *    [
+ *       route('home'),
+ *       route('customer', { path: 'customer/:customer_id' }),
+ *    ]
+ *
+ * It represents a leaf (child-less) route in the routing tree.
+ */
+export class RouteReducer implements RouteableReducer {
   name: string;
   children: RouteableReducer[];
   options: RouteOptions;

--- a/addon/-private/routeable.ts
+++ b/addon/-private/routeable.ts
@@ -63,6 +63,7 @@ export interface MountableNode {
   key: string;
   params: any;
   routeName: string;
+  parentNode: MountableNode | null;
 }
 
 export interface Resolver {

--- a/addon/-private/routeable.ts
+++ b/addon/-private/routeable.ts
@@ -50,11 +50,6 @@ export interface RouteableReducer {
   reconcile(routerState: RouteableState, mountedNode: MountableNode) : void;
 };
 
-export interface RouteReducer extends RouteableReducer {
-  isRouter: false;
-  getInitialState: (options?: InitialStateOptions) => RouteState;
-}
-
 export interface RouterReducer extends RouteableReducer {
   isRouter: true;
   getInitialState: (options?: InitialStateOptions) => RouterState;
@@ -67,6 +62,7 @@ export interface MountableNode {
   mountedRouter: any;
   key: string;
   params: any;
+  routeName: string;
 }
 
 export interface Resolver {

--- a/addon/-private/routers/stack-router.ts
+++ b/addon/-private/routers/stack-router.ts
@@ -23,7 +23,7 @@ import {
   handledAction,
   unhandledAction
 } from "./base-router";
-import { MountedNodeSet, MountedNode } from "../mounted-router";
+import { MountedNodeSet, MountedNode } from "../mounted-node";
 
 export interface StackOptions extends BaseOptions {
   headerComponentName?: string;

--- a/addon/-private/routers/stack-router.ts
+++ b/addon/-private/routers/stack-router.ts
@@ -225,21 +225,24 @@ export class StackRouter extends BaseRouter implements RouterReducer {
     let currentChildNodes = mountedNode.childNodes;
     let nextChildNodes: MountedNodeSet = {};
 
+    let parentRoute: MountedNode = mountedNode;
     routerState.routes.forEach(childRouteState => {
       let childNode = currentChildNodes[childRouteState.key];
       if (childNode && childNode.routeableState === childRouteState) {
         // child state hasn't changed in any way, don't recurse/update
-        // TODO: this next line is duplicated below... how can we DRY/clean it
+        // TODO: the next two lines are duplicated below... how can we DRY/clean it
         nextChildNodes[childRouteState.key] = childNode;
+        parentRoute = childNode;
         return;
       } else if (!childNode) {
-        childNode = new MountedNode(mountedNode.mountedRouter, childRouteState);
+        childNode = new MountedNode(mountedNode.mountedRouter, parentRoute, childRouteState);
       }
 
       let childRouteableReducer = this.childRouteables[childRouteState.routeName];
       childRouteableReducer.reconcile(childRouteState, childNode);
 
       nextChildNodes[childRouteState.key] = childNode;
+      parentRoute = childNode;
     });
 
     Object.keys(currentChildNodes).forEach(key => {

--- a/addon/-private/routers/stack-router.ts
+++ b/addon/-private/routers/stack-router.ts
@@ -225,24 +225,24 @@ export class StackRouter extends BaseRouter implements RouterReducer {
     let currentChildNodes = mountedNode.childNodes;
     let nextChildNodes: MountedNodeSet = {};
 
-    let parentRoute: MountedNode = mountedNode;
+    let parent: MountedNode = mountedNode;
     routerState.routes.forEach(childRouteState => {
       let childNode = currentChildNodes[childRouteState.key];
       if (childNode && childNode.routeableState === childRouteState) {
         // child state hasn't changed in any way, don't recurse/update
         // TODO: the next two lines are duplicated below... how can we DRY/clean it
         nextChildNodes[childRouteState.key] = childNode;
-        parentRoute = childNode;
+        parent = childNode;
         return;
       } else if (!childNode) {
-        childNode = new MountedNode(mountedNode.mountedRouter, parentRoute, childRouteState);
+        childNode = new MountedNode(mountedNode.mountedRouter, parent, childRouteState);
       }
 
       let childRouteableReducer = this.childRouteables[childRouteState.routeName];
       childRouteableReducer.reconcile(childRouteState, childNode);
 
       nextChildNodes[childRouteState.key] = childNode;
-      parentRoute = childNode;
+      parent = childNode;
     });
 
     Object.keys(currentChildNodes).forEach(key => {

--- a/addon/-private/routers/switch-router.ts
+++ b/addon/-private/routers/switch-router.ts
@@ -122,7 +122,7 @@ export class SwitchRouter extends BaseRouter implements RouterReducer {
     let currentActiveNode = currentChildNodes[activeChildRouteState.key];
 
     if (!currentActiveNode) {
-      currentActiveNode = new MountedNode(mountedNode.mountedRouter, activeChildRouteState);
+      currentActiveNode = new MountedNode(mountedNode.mountedRouter, mountedNode, activeChildRouteState);
     }
 
     let childRouteableReducer = this.childRouteables[activeChildRouteState.routeName];

--- a/addon/-private/routers/switch-router.ts
+++ b/addon/-private/routers/switch-router.ts
@@ -13,7 +13,7 @@ import {
   unhandledAction
 } from "./base-router";
 import { RouterActions, NAVIGATE, NavigateAction } from "../actions/types";
-import { MountedNode, MountedNodeSet } from "../mounted-router";
+import { MountedNode, MountedNodeSet } from "../mounted-node";
 
 export interface SwitchOptions extends BaseOptions {}
 

--- a/addon/components/ecr-switch.ts
+++ b/addon/components/ecr-switch.ts
@@ -3,7 +3,7 @@ import Component from '@ember/component';
 import layout from '../templates/components/ecr-switch';
 import { computed } from '@ember/object';
 import { RouterState } from 'ember-navigator/-private/routeable';
-import { MountedNode } from 'ember-navigator/-private/mounted-router';
+import { MountedNode } from 'ember-navigator/-private/mounted-node';
 
 export default class EcrSwitch extends Component.extend({
   tagName: null,

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,6 +1,6 @@
 import MountedRouter from "./-private/mounted-router";
 import { RouterReducer, RouteableReducer, Resolver } from "./-private/routeable";
-import { RouteOptions, Route } from "./-private/route";
+import { RouteOptions, RouteReducer } from "./-private/route-reducer";
 import { StackOptions, StackRouter } from "./-private/routers/stack-router";
 import { SwitchOptions, SwitchRouter } from "./-private/routers/switch-router";
 import { TabOptions, TabRouter } from "./-private/routers/tab-router";
@@ -12,7 +12,7 @@ export function mount(routerMap: RouterReducer, resolver: Resolver) : MountedRou
 }
 
 export function route(name: string, options: RouteOptions = {}) {
-  return new Route(name, options);
+  return new RouteReducer(name, options);
 }
 
 export function stackRouter(name: string, children: RouteableReducer[], options: StackOptions = {}) {

--- a/tests/unit/mounted-router-test.ts
+++ b/tests/unit/mounted-router-test.ts
@@ -141,9 +141,18 @@ module('Unit - MountedRouter test', function(hooks) {
     ]);
 
     const fooRoute = mountedRouter.rootNode.childNodes['foo'].route;
+    assert.equal(fooRoute.key, 'foo');
+
     const barRoute = mountedRouter.rootNode.childNodes['id-1'].route;
     assert.equal(barRoute.name, 'bar');
-    assert.equal(barRoute.parentRoute, fooRoute);
+    assert.equal(barRoute.key, 'id-1');
+    assert.equal(barRoute.parent, fooRoute);
+    assert.equal(barRoute.parent!.parent!.name, 'root');
+
+    assert.equal(barRoute.parent?.parentRoute, null);
+
+    assert.equal(barRoute.parentRouter!.name, 'root');
+    assert.equal(barRoute.parent!.parentRouter!.name, 'root');
   });
 
   test("stack: basic nav with params", function (assert) {

--- a/tests/unit/mounted-router-test.ts
+++ b/tests/unit/mounted-router-test.ts
@@ -140,9 +140,10 @@ module('Unit - MountedRouter test', function(hooks) {
       }
     ]);
 
+    const fooRoute = mountedRouter.rootNode.childNodes['foo'].route;
     const barRoute = mountedRouter.rootNode.childNodes['id-1'].route;
     assert.equal(barRoute.name, 'bar');
-    // const fooRoute = barRoute.parentRoute;
+    assert.equal(barRoute.parentRoute, fooRoute);
   });
 
   test("stack: basic nav with params", function (assert) {

--- a/tests/unit/mounted-router-test.ts
+++ b/tests/unit/mounted-router-test.ts
@@ -3,7 +3,7 @@ import { route, switchRouter, stackRouter } from 'ember-navigator';
 import { _TESTING_ONLY_normalize_keys } from 'ember-navigator/-private/key-generator';
 import MountedRouter from 'ember-navigator/-private/mounted-router';
 import { Resolver } from 'ember-navigator/-private/routeable';
-import NavigatorRoute from 'ember-navigator/-private/navigator-route';
+import { NavigatorRoute } from 'ember-navigator';
 
 function buildTestResolver() {
   let events: any[] = [];
@@ -22,12 +22,6 @@ function buildTestResolver() {
 
     mount() {
       events.push({ id: this.id, type: "mount", key: this.node.key});
-    }
-
-    focus() {
-    }
-
-    blur() {
     }
   }
 
@@ -145,6 +139,10 @@ module('Unit - MountedRouter test', function(hooks) {
         "type": "update"
       }
     ]);
+
+    const barRoute = mountedRouter.rootNode.childNodes['id-1'].route;
+    assert.equal(barRoute.name, 'bar');
+    // const fooRoute = barRoute.parentRoute;
   });
 
   test("stack: basic nav with params", function (assert) {


### PR DESCRIPTION
It's a common use case to grab some value off of a parent route; previously this was only possible by hacking into the private "node" API; this PR exposes more useful methods / getters on the public NavigatorRoute API to make it more easy to pull values off parent routes.