### PR TITLE
Allow/encourage NavigatorRoute ctor overrides

### DIFF
--- a/addon/-private/mounted-node.ts
+++ b/addon/-private/mounted-node.ts
@@ -38,8 +38,8 @@ export class MountedNode {
     this.mountedRouter = mountedRouter;
     this.parentNode = parentNode;
     this.routeableState = routeableState;
-    this.route = this.mountedRouter.createNavigatorRoute(this);
     this.childNodes = {};
+    this.route = this.mountedRouter.createNavigatorRoute(this);
     this.mount();
   }
 

--- a/addon/-private/navigator-route.ts
+++ b/addon/-private/navigator-route.ts
@@ -8,6 +8,8 @@ export type Header = {
   title?: string;
 };
 
+export type NavigatorRouteConstructorParams = [node: MountedNode];
+
 /**
  * NavigatorRoute is part of the public API of ember-navigator; it is a class
  * that is meant to be subclassed with various lifecycle hooks that can be
@@ -17,8 +19,14 @@ export default class NavigatorRoute {
   node: MountedNode;
   header?: Header;
 
-  constructor(node: MountedNode) {
-    this.node = node;
+  /**
+   * Constructs a NavigatorRoute, which you can override in your NavigatorRoute subclasses
+   * to load data or perform other operations when the route is mounted.
+   *
+   * @param params NavigatorRouteConstructorParams
+   */
+  constructor(...params: NavigatorRouteConstructorParams) {
+    this.node = params[0];
   }
 
   static create(props: { node: MountedNode }) {
@@ -130,6 +138,10 @@ export default class NavigatorRoute {
    * `mount` is called after transitioning to a new route, or pushing a stack frame;
    * Within this hook, you can access `this.params` to access any params passed into
    * this route (such as model IDs or any other information)
+   *
+   * There is no difference between overriding this method vs just overriding the
+   * NavigatorRoute constructor (and calling super()), but overriding the constructor
+   * tends to be the happier path when working with TypeScript
    */
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   mount() {}

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -10,7 +10,10 @@ import type { StackOptions } from './-private/routers/stack-router';
 import type { SwitchOptions } from './-private/routers/switch-router';
 import type { TabOptions } from './-private/routers/tab-router';
 
-export { default as NavigatorRoute } from './-private/navigator-route';
+export {
+  default as NavigatorRoute,
+  NavigatorRouteConstructorParams,
+} from './-private/navigator-route';
 
 export function mount(routerMap: RouterReducer, resolver: Resolver): MountedRouter {
   return new MountedRouter(routerMap, resolver);

--- a/tests/unit/mounted-router-test.ts
+++ b/tests/unit/mounted-router-test.ts
@@ -5,6 +5,7 @@ import { NavigatorRoute } from 'ember-navigator';
 import { _TESTING_ONLY_normalize_keys } from 'ember-navigator/-private/key-generator';
 import MountedRouter from 'ember-navigator/-private/mounted-router';
 
+import type { NavigatorRouteConstructorParams } from 'ember-navigator';
 import type { Resolver } from 'ember-navigator/-private/routeable';
 
 interface TestEvent {
@@ -19,6 +20,11 @@ function buildTestResolver() {
 
   class Route extends NavigatorRoute {
     id: number = delegateId++;
+
+    constructor(...params: NavigatorRouteConstructorParams) {
+      super(...params);
+      events.push({ id: this.id, type: 'constructor', key: this.node.key });
+    }
 
     update() {
       events.push({ id: this.id, type: 'update', key: this.node.key });
@@ -63,6 +69,11 @@ module('Unit - MountedRouter test', function (hooks) {
       {
         id: 2,
         key: 'bar',
+        type: 'constructor',
+      },
+      {
+        id: 2,
+        key: 'bar',
         type: 'mount',
       },
       {
@@ -97,7 +108,17 @@ module('Unit - MountedRouter test', function (hooks) {
       {
         id: 0,
         key: 'StackRouterRoot',
+        type: 'constructor',
+      },
+      {
+        id: 0,
+        key: 'StackRouterRoot',
         type: 'mount',
+      },
+      {
+        id: 1,
+        key: 'foo',
+        type: 'constructor',
       },
       {
         id: 1,
@@ -125,6 +146,11 @@ module('Unit - MountedRouter test', function (hooks) {
     events.length = 0;
     mountedRouter.navigate({ routeName: 'bar' });
     assert.deepEqual(events, [
+      {
+        id: 2,
+        key: 'id-1',
+        type: 'constructor',
+      },
       {
         id: 2,
         key: 'id-1',
@@ -165,6 +191,11 @@ module('Unit - MountedRouter test', function (hooks) {
     events.length = 0;
     mountedRouter.navigate({ routeName: 'bar', params: { bar_id: 123 } });
     assert.deepEqual(events, [
+      {
+        id: 2,
+        key: 'id-1',
+        type: 'constructor',
+      },
       {
         id: 2,
         key: 'id-1',


### PR DESCRIPTION
If you override a NavigatorRoute and add some fields to the class, those fields need to be annotated with `?` or `|  null` or you can cheat with `!` because they're not being initialized in the constructor; they're being initialized in `mount()`.

There's actually no functional difference between putting this logic in the ctor vs mount, but to override the ctor, you need to import the private MountedNode type and call super with it. This PR introduces the public `NavigatorRouteConstructorParams` type to allow for the following pattern:

```ts
import { NavigatorRoute } from 'ember-navigator';
import type { NavigatorRouteConstructorParams } from 'ember-navigator';

class MyNavigatorRoute extends NavigatorRoute {
  myData: string;
  constructor(...params: NavigatorRouteConstructorParams) {
    super(...params);

    this.myData = 'foo';
  }
}
``` 